### PR TITLE
fix -  issue with oci repo url having port

### DIFF
--- a/pkg/apis/application/v1alpha1/repository_types.go
+++ b/pkg/apis/application/v1alpha1/repository_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 
 	"github.com/argoproj/argo-cd/v2/util/cert"
@@ -243,8 +244,15 @@ func getCAPath(repoURL string) string {
 	}
 
 	if hostname == "" {
-		log.Warnf("Could not get hostname for repository '%s'", repoURL)
-		return ""
+		hostname, _, err = net.SplitHostPort(repoURL)
+		if err != nil {
+			log.Warnf("Could not parse repo URL '%s': %v", repoURL, err)
+			return ""
+		}
+		if hostname == "" {
+			log.Warnf("Could not get hostname for repository '%s'", repoURL)
+			return ""
+		}
 	}
 
 	caPath, err := cert.GetCertBundlePathForRepository(hostname)


### PR DESCRIPTION
When repo url is like registry.example.com:5000 both `parsedURL.Host` and `parsedURL.Path` are empty on the parsed URL.
Because of this certificate is not being loaded.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
